### PR TITLE
Add more types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ serde = { version = "???", features = ["derive"] }
 serde_molecule = { version = "???" }
 ```
 Then to annotate the types with `#[derive(Serialize, Deserialize)]`. After that,
-use `to_vec` or `from_slice` to serialize/deserialize. 
+use `to_vec` or `from_slice` to serialize/deserialize.
 
 ## Types mapping
 
@@ -61,6 +61,11 @@ Rust types are mapping to molecule types, according to the [RFC](https://github.
 | LinkedList | fixvec | no |
 | VecDeque   | fixvec | no |
 | HashSet    | fixvec | no |
+| Tuple Struct|table  | no |
+| Tuple Variant|table | no |
+| Struct Variant|table| no |
+| Tuple     | not supported | N/A|
+
 
 By default, `Vec`-like containers (such as `Vec`, `BinaryHeap`, etc.) are
 serialized into `fixvec`. Every element in the `Vec` must have a fixed size

--- a/serde_molecule/Cargo.toml
+++ b/serde_molecule/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_molecule"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["xjd <lynndon@gmail.com>"]
 categories = ["encoding", "parser-implementations", "no-std"]
 description = "Implementation of Molecule using Serde."
@@ -11,7 +11,7 @@ license = "MIT"
 repository = "https://github.com/XuJiandong/serde_molecule"
 
 [dependencies]
-serde = { version = "1.0.208", default-features = false }
+serde = { version = "1.0.210", default-features = false }
 
 [dev-dependencies]
 

--- a/tests/src/test_serde.rs
+++ b/tests/src/test_serde.rs
@@ -214,3 +214,21 @@ fn test_union_with_dynvec() {
     let variant = UnionWithDynvec::DynvecVariant(vs);
     test_once(&variant);
 }
+
+#[derive(Serialize)]
+struct StructWithDynVec {
+    #[serde(serialize_with = "dynvec_serde::serialize")]
+    pub v: Vec<Vec<u8>>,
+}
+
+#[test]
+fn test_result() {
+    let mut value = Struct1::default();
+    value.f1 = 100;
+    value.f2 = 200;
+    value.f3 = [1, 2, 3];
+    value.f4 = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]];
+
+    let result: Result<Struct1, ()> = Ok(value);
+    test_once(&result);
+}

--- a/tests/src/test_serde.rs
+++ b/tests/src/test_serde.rs
@@ -232,3 +232,44 @@ fn test_result() {
     let result: Result<Struct1, ()> = Ok(value);
     test_once(&result);
 }
+
+#[derive(Serialize, Deserialize)]
+enum StructVariant {
+    Method1 { arg1: u64, arg2: String },
+    Method2 { arg1: u8, arg2: u16 },
+}
+
+#[test]
+fn test_struct_variant() {
+    let var = StructVariant::Method1 {
+        arg1: 123,
+        arg2: "hello".into(),
+    };
+    test_once(&var);
+}
+
+#[derive(Serialize, Deserialize)]
+struct TupleStruct(u8, u16, String);
+
+#[derive(Serialize, Deserialize)]
+struct NewType(String);
+
+#[test]
+fn test_tuple_struct() {
+    let ts = TupleStruct(1, 2, "hello".into());
+    test_once(&ts);
+    let nt = NewType("hello".into());
+    test_once(&nt);
+}
+
+#[derive(Serialize, Deserialize)]
+enum TupleVariant {
+    TupleVariant1(u8, u16, String),
+    TupleVariant2(u32, u64),
+}
+
+#[test]
+fn test_tuple_variant() {
+    let tv = TupleVariant::TupleVariant1(1, 2, "hello".into());
+    test_once(&tv);
+}


### PR DESCRIPTION
Add new types:
- tuple struct
- tuple variant
- struct variant

They are all mapping to molecule table.

The `serde` treats tuples (e.g., `(u8, String)`) the same as arrays (e.g., `[u8; 2]`), which leads to inadequate support.
See [serde implementation](https://github.com/serde-rs/serde/blob/4b3178b053683b8e13f9f551e2a40fbe4a927e43/serde/src/ser/impls.rs#L155-L159)
