### PR TITLE
chore: update Rust toolchain and improve code consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: 1.85.0
           components: rustfmt
       - name: Run
         run: make fmt
@@ -32,7 +32,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: 1.85.0
           components: clippy
       - name: Run
         run: make clippy
@@ -44,7 +44,7 @@ jobs:
       - name: Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75.0
+          toolchain: 1.85.0
       - name: Run
         run: |
           cd examples/serde_molecule_nostd; make prepare; cd ../..

--- a/README.md
+++ b/README.md
@@ -19,14 +19,12 @@ pub struct Table1 {
     pub f2: u16,
 }
 
-fn main() {
-    let t1 = Table1{f1: 0, f2: 0};
-    // serialize
-    let bytes = to_vec(&t1, false).unwrap();
-    // deserialize
-    let t2: Table1 = from_slice(&bytes, false).unwrap();
-    assert_eq!(t1.f1, t2.f1);
-}
+let t1 = Table1{f1: 0, f2: 0};
+// serialize
+let bytes = to_vec(&t1, false).unwrap();
+// deserialize
+let t2: Table1 = from_slice(&bytes, false).unwrap();
+assert_eq!(t1.f1, t2.f1);
 ```
 First step is to add dependency in Cargo.toml:
 ```toml

--- a/examples/serde_molecule_nostd/Makefile
+++ b/examples/serde_molecule_nostd/Makefile
@@ -6,7 +6,7 @@ TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,
 # while we enable debug logs by default here, some might want to strip them
 # for minimal code size / consumed cycles.
-CUSTOM_RUSTFLAGS := --cfg debug_assertions
+CUSTOM_RUSTFLAGS := -C debug_assertions
 # RUSTFLAGS that are less likely to be tweaked by developers. Most likely
 # one would want to keep the default values here.
 FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs $(CUSTOM_RUSTFLAGS)
@@ -61,7 +61,7 @@ fmt:
 # Arbitrary cargo command is supported here. For example:
 #
 # make cargo CARGO_CMD=expand CARGO_ARGS="--ugly"
-# 
+#
 # Invokes:
 # cargo expand --ugly
 CARGO_CMD :=

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85.0"

--- a/serde_molecule/src/de.rs
+++ b/serde_molecule/src/de.rs
@@ -16,8 +16,7 @@ pub(crate) const DYNVEC_STR: &str = "$serde_molecule::DynVec";
 /// Deserialize an instance of type `T` from bytes of molecule.
 ///
 /// Arguments
-/// * is_struct - mapping to molecule struct. Set to false to map to molecule
-/// table.
+/// * is_struct - mapping to molecule struct. Set to false to map to molecule table.
 pub fn from_slice<'a, T>(v: &'a [u8], is_struct: bool) -> Result<T>
 where
     T: de::Deserialize<'a>,
@@ -81,7 +80,7 @@ impl<'de> MoleculeDeserializer<'de> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut MoleculeDeserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut MoleculeDeserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -364,7 +363,7 @@ impl<'de, 'a> ArrayAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::SeqAccess<'de> for ArrayAccess<'de, 'a> {
+impl<'de> de::SeqAccess<'de> for ArrayAccess<'de, '_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -404,7 +403,7 @@ impl<'de, 'a> FixvecAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::SeqAccess<'de> for FixvecAccess<'de, 'a> {
+impl<'de> de::SeqAccess<'de> for FixvecAccess<'de, '_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -450,7 +449,7 @@ impl<'de, 'a> TableAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::MapAccess<'de> for TableAccess<'de, 'a> {
+impl<'de> de::MapAccess<'de> for TableAccess<'de, '_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -478,7 +477,7 @@ impl<'de, 'a> de::MapAccess<'de> for TableAccess<'de, 'a> {
 }
 
 // used for tuple struct
-impl<'de, 'a> de::SeqAccess<'de> for TableAccess<'de, 'a> {
+impl<'de> de::SeqAccess<'de> for TableAccess<'de, '_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -516,7 +515,7 @@ impl<'de, 'a> MappingAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::MapAccess<'de> for MappingAccess<'de, 'a> {
+impl<'de> de::MapAccess<'de> for MappingAccess<'de, '_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -564,7 +563,7 @@ impl<'de, 'a> DynvecAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::MapAccess<'de> for DynvecAccess<'de, 'a> {
+impl<'de> de::MapAccess<'de> for DynvecAccess<'de, '_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -601,7 +600,7 @@ impl<'de, 'a> UnionAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::EnumAccess<'de> for UnionAccess<'de, 'a> {
+impl<'de> de::EnumAccess<'de> for UnionAccess<'de, '_> {
     type Error = Error;
     type Variant = Self;
 
@@ -616,7 +615,7 @@ impl<'de, 'a> de::EnumAccess<'de> for UnionAccess<'de, 'a> {
     }
 }
 
-impl<'de, 'a> de::VariantAccess<'de> for UnionAccess<'de, 'a> {
+impl<'de> de::VariantAccess<'de> for UnionAccess<'de, '_> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/serde_molecule/src/molecule.rs
+++ b/serde_molecule/src/molecule.rs
@@ -13,7 +13,7 @@ const NUMBER_SIZE: usize = 4;
 /// * Serialize all offset of fields as 32 bit unsigned integer in little-endian.
 /// * Serialize all fields in it in the order they are declared.
 ///
-pub fn assemble_table(parts: &Vec<Vec<u8>>) -> Vec<u8> {
+pub fn assemble_table(parts: &[Vec<u8>]) -> Vec<u8> {
     let header_len = parts.len() + 1;
     let mut header = vec![0u32; header_len];
     let mut offset = (header_len * 4) as u32;

--- a/serde_molecule/src/ser.rs
+++ b/serde_molecule/src/ser.rs
@@ -8,8 +8,7 @@ use serde::ser::{self, Serialize};
 /// Serialize the given data structure to byte vector.
 ///
 /// Arguments
-/// * is_struct - mapping to molecule struct. Set to false to map to molecule
-/// table.
+/// * is_struct - mapping to molecule struct. Set to false to map to molecule table.
 pub fn to_vec<T>(value: &T, is_struct: bool) -> Result<Vec<u8>>
 where
     T: ?Sized + Serialize,
@@ -51,16 +50,11 @@ impl From<MoleculeSerializer> for Vec<u8> {
 
 impl MoleculeSerializer {
     pub fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
-        self.data.extend(iter.into_iter());
+        self.data.extend(iter);
     }
     pub fn is_struct(&self) -> bool {
         self.is_struct
     }
-}
-
-// dummy
-pub(crate) struct Compound<'a> {
-    _ser: &'a mut MoleculeSerializer,
 }
 
 impl<'a> ser::Serializer for &'a mut MoleculeSerializer {
@@ -191,7 +185,6 @@ impl<'a> ser::Serializer for &'a mut MoleculeSerializer {
     }
 
     /// Serialize newtypes without an object wrapper.
-
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
@@ -287,7 +280,7 @@ impl<'a> FixVec<'a> {
     }
 }
 
-impl<'a> ser::SerializeSeq for FixVec<'a> {
+impl ser::SerializeSeq for FixVec<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -317,7 +310,7 @@ impl<'a> Tuple<'a> {
     }
 }
 
-impl<'a> ser::SerializeTuple for Tuple<'a> {
+impl ser::SerializeTuple for Tuple<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -353,7 +346,7 @@ impl<'a> Table<'a> {
     }
 }
 
-impl<'a> ser::SerializeStruct for Table<'a> {
+impl ser::SerializeStruct for Table<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -380,7 +373,7 @@ impl<'a> ser::SerializeStruct for Table<'a> {
     }
 }
 
-impl<'a> ser::SerializeTupleStruct for Table<'a> {
+impl ser::SerializeTupleStruct for Table<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -411,7 +404,7 @@ impl<'a> Map<'a> {
     }
 }
 
-impl<'a> ser::SerializeMap for Map<'a> {
+impl ser::SerializeMap for Map<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -442,38 +435,6 @@ impl<'a> ser::SerializeMap for Map<'a> {
     }
 }
 
-impl<'a> ser::SerializeTupleStruct for Compound<'a> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Error::Unimplemented)
-    }
-
-    fn end(self) -> Result<()> {
-        Err(Error::Unimplemented)
-    }
-}
-
-impl<'a> ser::SerializeTupleVariant for Compound<'a> {
-    type Ok = ();
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(Error::Unimplemented)
-    }
-
-    fn end(self) -> Result<()> {
-        Err(Error::Unimplemented)
-    }
-}
-
 pub(crate) struct Variant<'a> {
     ser: &'a mut MoleculeSerializer,
     parts: Vec<Vec<u8>>,
@@ -499,7 +460,7 @@ impl<'a> Variant<'a> {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for Variant<'a> {
+impl ser::SerializeStructVariant for Variant<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -525,7 +486,7 @@ impl<'a> ser::SerializeStructVariant for Variant<'a> {
     }
 }
 
-impl<'a> ser::SerializeTupleVariant for Variant<'a> {
+impl ser::SerializeTupleVariant for Variant<'_> {
     type Ok = ();
     type Error = Error;
 

--- a/serde_molecule/src/struct_serde.rs
+++ b/serde_molecule/src/struct_serde.rs
@@ -48,7 +48,7 @@ impl<'de> Deserialize<'de> for CollectData {
         D: Deserializer<'de>,
     {
         struct _Visitor;
-        impl<'de> Visitor<'de> for _Visitor {
+        impl Visitor<'_> for _Visitor {
             type Value = CollectData;
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a CollectData")
@@ -110,7 +110,7 @@ impl MoleculeStructDeserializer {
     read_primitive!(read_f64, f64, 8);
 }
 
-impl<'de, 'a> Deserializer<'de> for &'a mut MoleculeStructDeserializer {
+impl<'de> Deserializer<'de> for &mut MoleculeStructDeserializer {
     type Error = Error;
 
     fn is_human_readable(&self) -> bool {
@@ -362,7 +362,7 @@ impl<'a> StructAccess<'a> {
     }
 }
 
-impl<'de, 'a> MapAccess<'de> for StructAccess<'a> {
+impl<'de> MapAccess<'de> for StructAccess<'_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
@@ -403,7 +403,7 @@ impl<'a> ArrayAccess<'a> {
     }
 }
 
-impl<'de, 'a> SeqAccess<'de> for ArrayAccess<'a> {
+impl<'de> SeqAccess<'de> for ArrayAccess<'_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>

--- a/serde_molecule/src/tests.rs
+++ b/serde_molecule/src/tests.rs
@@ -115,7 +115,7 @@ fn test_disassemble_table() {
     assert_eq!(result[4].len(), 7);
 }
 
-fn test_table(data: &Vec<Vec<u8>>) {
+fn test_table(data: &[Vec<u8>]) {
     let result1 = assemble_table(data);
     let result2 = disassemble_table(&result1);
     let result2 = result2.unwrap();
@@ -128,16 +128,16 @@ fn test_table(data: &Vec<Vec<u8>>) {
 
 #[test]
 fn test_assemble_table() {
-    test_table(&vec![]);
-    test_table(&vec![vec![]]);
-    test_table(&vec![vec![1]]);
-    test_table(&vec![vec![1, 2, 3]]);
-    test_table(&vec![vec![], vec![]]);
-    test_table(&vec![vec![], vec![1]]);
-    test_table(&vec![vec![1], vec![]]);
-    test_table(&vec![vec![], vec![1], vec![2]]);
-    test_table(&vec![vec![1], vec![], vec![2]]);
-    test_table(&vec![vec![1], vec![2], vec![]]);
-    test_table(&vec![vec![1], vec![2], vec![3]]);
-    test_table(&vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
+    test_table(&[]);
+    test_table(&[vec![]]);
+    test_table(&[vec![1]]);
+    test_table(&[vec![1, 2, 3]]);
+    test_table(&[vec![], vec![]]);
+    test_table(&[vec![], vec![1]]);
+    test_table(&[vec![1], vec![]]);
+    test_table(&[vec![], vec![1], vec![2]]);
+    test_table(&[vec![1], vec![], vec![2]]);
+    test_table(&[vec![1], vec![2], vec![]]);
+    test_table(&[vec![1], vec![2], vec![3]]);
+    test_table(&[vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
 }


### PR DESCRIPTION
* Update Rust toolchain version to 1.85.0 in CI configuration and add rust-toolchain.toml.
* Refactor code for consistency by changing function signatures to use slices instead of vectors.
* Clean up comments and remove unused struct definitions in serialization code.