### PR TITLE
feat: Add conditional serialization/deserialization logic to support multiple serialization formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ unit-tests:
 
 example-tests:
 	cargo run --bin serde_molecule_customized_union_id
-	cd examples/serde_molecule_nostd; make build; cd ../..
+	cd examples/serde_molecule_nostd && make build && cd ../..
 
 mol-gen:
 	moleculec --schema-file tests/schemas/test1.mol --language rust | rustfmt > tests/src/old/test1.rs

--- a/serde_molecule/src/dynvec_serde.rs
+++ b/serde_molecule/src/dynvec_serde.rs
@@ -14,35 +14,43 @@ pub fn serialize<T, S, V>(value: V, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     T: Serialize,
-    V: IntoIterator<Item = T>,
+    V: IntoIterator<Item = T> + Serialize,
 {
-    let parts: Result<Vec<_>, _> = value
-        .into_iter()
-        .map(|v| {
-            to_vec(&v, false)
-                .map_err(|_| ser::Error::custom("failed to serialize element in vector"))
-        })
-        .collect();
+    if std::any::type_name::<S>().contains("serde_molecule") {
+        let parts: Result<Vec<_>, _> = value
+            .into_iter()
+            .map(|v| {
+                to_vec(&v, false)
+                    .map_err(|_| ser::Error::custom("failed to serialize element in vector"))
+            })
+            .collect();
 
-    let parts = parts?; // Propagate error if any element fails to serialize.
-    let data = assemble_table(&parts);
-    serializer.serialize_bytes(&data)
+        let parts = parts?; // Propagate error if any element fails to serialize.
+        let data = assemble_table(&parts);
+        serializer.serialize_bytes(&data)
+    } else {
+        value.serialize(serializer) // Use default serialization for others, e.g. serde_json
+    }
 }
 
 pub fn deserialize<'de, D, T, V>(deserializer: D) -> Result<V, D::Error>
 where
     D: Deserializer<'de>,
-    V: FromIterator<T>,
+    V: FromIterator<T> + Deserialize<'de>,
     T: Deserialize<'de>,
 {
-    deserializer.deserialize_struct(
-        DYNVEC_STR,
-        &[],
-        DynvecVisitor {
-            marker: PhantomData,
-            lifetime: PhantomData,
-        },
-    )
+    if std::any::type_name::<D>().contains("serde_molecule") {
+        deserializer.deserialize_struct(
+            DYNVEC_STR,
+            &[],
+            DynvecVisitor {
+                marker: PhantomData,
+                lifetime: PhantomData,
+            },
+        )
+    } else {
+        V::deserialize(deserializer)
+    }
 }
 
 struct DynvecVisitor<'de, T: Deserialize<'de>, V: FromIterator<T>> {

--- a/serde_molecule/src/dynvec_serde.rs
+++ b/serde_molecule/src/dynvec_serde.rs
@@ -16,7 +16,7 @@ where
     T: Serialize,
     V: IntoIterator<Item = T> + Serialize,
 {
-    if std::any::type_name::<S>().contains("serde_molecule") {
+    if core::any::type_name::<S>().contains("serde_molecule") {
         let parts: Result<Vec<_>, _> = value
             .into_iter()
             .map(|v| {
@@ -39,7 +39,7 @@ where
     V: FromIterator<T> + Deserialize<'de>,
     T: Deserialize<'de>,
 {
-    if std::any::type_name::<D>().contains("serde_molecule") {
+    if core::any::type_name::<D>().contains("serde_molecule") {
         deserializer.deserialize_struct(
             DYNVEC_STR,
             &[],

--- a/serde_molecule/src/dynvec_serde.rs
+++ b/serde_molecule/src/dynvec_serde.rs
@@ -4,7 +4,10 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use crate::to_vec;
-use crate::{de::DYNVEC_STR, molecule::assemble_table};
+use crate::{
+    de::DYNVEC_STR,
+    molecule::{assemble_table, SERDE_MOLECULE_TYPE},
+};
 use serde::{
     de::{MapAccess, Visitor},
     ser, Deserialize, Deserializer, Serialize, Serializer,
@@ -16,7 +19,7 @@ where
     T: Serialize,
     V: IntoIterator<Item = T> + Serialize,
 {
-    if core::any::type_name::<S>().contains("serde_molecule") {
+    if core::any::type_name::<S>().contains(SERDE_MOLECULE_TYPE) {
         let parts: Result<Vec<_>, _> = value
             .into_iter()
             .map(|v| {
@@ -39,7 +42,7 @@ where
     V: FromIterator<T> + Deserialize<'de>,
     T: Deserialize<'de>,
 {
-    if core::any::type_name::<D>().contains("serde_molecule") {
+    if core::any::type_name::<D>().contains(SERDE_MOLECULE_TYPE) {
         deserializer.deserialize_struct(
             DYNVEC_STR,
             &[],

--- a/serde_molecule/src/dynvec_serde.rs
+++ b/serde_molecule/src/dynvec_serde.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use crate::to_vec;
 use crate::{
     de::DYNVEC_STR,
-    molecule::{assemble_table, SERDE_MOLECULE_TYPE},
+    molecule::{assemble_table, MOLECULE_DE, MOLECULE_SER},
 };
 use serde::{
     de::{MapAccess, Visitor},
@@ -19,7 +19,7 @@ where
     T: Serialize,
     V: IntoIterator<Item = T> + Serialize,
 {
-    if core::any::type_name::<S>().contains(SERDE_MOLECULE_TYPE) {
+    if core::any::type_name::<S>().contains(MOLECULE_SER) {
         let parts: Result<Vec<_>, _> = value
             .into_iter()
             .map(|v| {
@@ -42,7 +42,7 @@ where
     V: FromIterator<T> + Deserialize<'de>,
     T: Deserialize<'de>,
 {
-    if core::any::type_name::<D>().contains(SERDE_MOLECULE_TYPE) {
+    if core::any::type_name::<D>().contains(MOLECULE_DE) {
         deserializer.deserialize_struct(
             DYNVEC_STR,
             &[],

--- a/serde_molecule/src/molecule.rs
+++ b/serde_molecule/src/molecule.rs
@@ -4,6 +4,8 @@ use alloc::vec::Vec;
 
 const NUMBER_SIZE: usize = 4;
 
+pub(crate) const SERDE_MOLECULE_TYPE: &str = "serde_molecule";
+
 ///
 /// Assemble molecule table or dynvec. See
 /// <https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0008-serialization/0008-serialization.md#table>

--- a/serde_molecule/src/molecule.rs
+++ b/serde_molecule/src/molecule.rs
@@ -4,7 +4,8 @@ use alloc::vec::Vec;
 
 const NUMBER_SIZE: usize = 4;
 
-pub(crate) const SERDE_MOLECULE_TYPE: &str = "serde_molecule";
+pub(crate) const MOLECULE_SER: &str = "MoleculeSerializer";
+pub(crate) const MOLECULE_DE: &str = "MoleculeDeserializer";
 
 ///
 /// Assemble molecule table or dynvec. See

--- a/serde_molecule/src/struct_serde.rs
+++ b/serde_molecule/src/struct_serde.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use crate::error::Error;
-use crate::molecule::SERDE_MOLECULE_TYPE;
+use crate::molecule::{MOLECULE_DE, MOLECULE_SER};
 use crate::ser::to_vec;
 use alloc::vec::Vec;
 use serde::de::DeserializeOwned;
@@ -16,7 +16,7 @@ where
     S: Serializer,
     T: Serialize,
 {
-    if core::any::type_name::<S>().contains(SERDE_MOLECULE_TYPE) {
+    if core::any::type_name::<S>().contains(MOLECULE_SER) {
         let data = to_vec(value, true).map_err(ser::Error::custom)?;
         serializer.serialize_bytes(&data)
     } else {
@@ -29,7 +29,7 @@ where
     D: Deserializer<'de>,
     T: DeserializeOwned,
 {
-    if core::any::type_name::<D>().contains(SERDE_MOLECULE_TYPE) {
+    if core::any::type_name::<D>().contains(MOLECULE_DE) {
         // This is a tricky approach: use this method to indicate that it is the top
         // level of the Molecule struct. When the inner `deserialize` is invoked, it
         // does not create a new instance. This ensures that the `index` status

--- a/serde_molecule/src/struct_serde.rs
+++ b/serde_molecule/src/struct_serde.rs
@@ -15,7 +15,7 @@ where
     S: Serializer,
     T: Serialize,
 {
-    if std::any::type_name::<S>().contains("serde_molecule") {
+    if core::any::type_name::<S>().contains("serde_molecule") {
         let data = to_vec(value, true).map_err(ser::Error::custom)?;
         serializer.serialize_bytes(&data)
     } else {
@@ -28,7 +28,7 @@ where
     D: Deserializer<'de>,
     T: DeserializeOwned,
 {
-    if std::any::type_name::<D>().contains("serde_molecule") {
+    if core::any::type_name::<D>().contains("serde_molecule") {
         // This is a tricky approach: use this method to indicate that it is the top
         // level of the Molecule struct. When the inner `deserialize` is invoked, it
         // does not create a new instance. This ensures that the `index` status

--- a/serde_molecule/src/struct_serde.rs
+++ b/serde_molecule/src/struct_serde.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use crate::error::Error;
+use crate::molecule::SERDE_MOLECULE_TYPE;
 use crate::ser::to_vec;
 use alloc::vec::Vec;
 use serde::de::DeserializeOwned;
@@ -15,7 +16,7 @@ where
     S: Serializer,
     T: Serialize,
 {
-    if core::any::type_name::<S>().contains("serde_molecule") {
+    if core::any::type_name::<S>().contains(SERDE_MOLECULE_TYPE) {
         let data = to_vec(value, true).map_err(ser::Error::custom)?;
         serializer.serialize_bytes(&data)
     } else {
@@ -28,7 +29,7 @@ where
     D: Deserializer<'de>,
     T: DeserializeOwned,
 {
-    if core::any::type_name::<D>().contains("serde_molecule") {
+    if core::any::type_name::<D>().contains(SERDE_MOLECULE_TYPE) {
         // This is a tricky approach: use this method to indicate that it is the top
         // level of the Molecule struct. When the inner `deserialize` is invoked, it
         // does not create a new instance. This ensures that the `index` status

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0.208", features = ["derive"] }
 molecule = { version = "0.8.0" }
 lazy_static = "1.5.0"
 ckb-gen-types = "0.117.0"
+serde_json = "1.0"

--- a/tests/src/test_serde.rs
+++ b/tests/src/test_serde.rs
@@ -215,10 +215,44 @@ fn test_union_with_dynvec() {
     test_once(&variant);
 }
 
-#[derive(Serialize)]
-struct StructWithDynVec {
-    #[serde(serialize_with = "dynvec_serde::serialize")]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct TableWithDynVec {
+    #[serde(with = "dynvec_serde")]
     pub v: Vec<Vec<u8>>,
+}
+
+#[test]
+fn test_work_with_serde_json() {
+    let s = TableWithDynVec {
+        v: vec![vec![1, 2, 3], vec![4, 5, 6]],
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let s2: TableWithDynVec = serde_json::from_str(&json).unwrap();
+    assert_eq!(s, s2);
+
+    let molecule = serde_molecule::to_vec(&s, false).unwrap();
+    let s3: TableWithDynVec = serde_molecule::from_slice(&molecule, false).unwrap();
+    assert_eq!(s, s3);
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct TableWithStruct {
+    #[serde(with = "struct_serde")]
+    pub v: StructInner,
+}
+
+#[test]
+fn test_work_with_serde_json_struct() {
+    let s = TableWithStruct {
+        v: StructInner { f0: 123 },
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let s2: TableWithStruct = serde_json::from_str(&json).unwrap();
+    assert_eq!(s, s2);
+
+    let molecule = serde_molecule::to_vec(&s, false).unwrap();
+    let s3: TableWithStruct = serde_molecule::from_slice(&molecule, false).unwrap();
+    assert_eq!(s, s3);
 }
 
 #[test]


### PR DESCRIPTION
Add conditional serialization/deserialization logic to support multiple serialization formats including serde_json. The implementation checks the serializer/deserializer type at runtime to determine the appropriate serialization path. This enables seamless integration with both molecule and JSON formats while maintaining backward compatibility. See `test_work_with_serde_json` and `test_work_with_serde_json_struct` for usage examples.